### PR TITLE
Use folder relative paths for AppAuth-JS dependency

### DIFF
--- a/AppAuth-JS-Ext-Logout/package.json
+++ b/AppAuth-JS-Ext-Logout/package.json
@@ -63,7 +63,7 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {
-    "@openid/appauth": "github:wso2-extensions/identity-client-lib-appauth/AppAuth-JS",
+    "@openid/appauth": "file://../AppAuth-JS",
     "@types/jquery": "^3.3.2",
     "follow-redirects": "^1.5.1",
     "form-data": "^2.3.2",

--- a/AppAuth-JS-Ext-PKCE/package.json
+++ b/AppAuth-JS-Ext-PKCE/package.json
@@ -63,7 +63,7 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {
-    "@openid/appauth": "github:wso2-extensions/identity-client-lib-appauth/AppAuth-JS",
+    "@openid/appauth": "file://../AppAuth-JS",
     "@types/jquery": "^3.3.2",
     "follow-redirects": "^1.5.1",
     "form-data": "^2.3.2",

--- a/AppAuth-JS-Ext-UserInfo/package.json
+++ b/AppAuth-JS-Ext-UserInfo/package.json
@@ -63,7 +63,7 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {
-    "@openid/appauth": "github:wso2-extensions/identity-client-lib-appauth/AppAuth-JS",
+    "@openid/appauth": "file://../AppAuth-JS",
     "@types/jquery": "^3.3.2",
     "follow-redirects": "^1.5.1",
     "form-data": "^2.3.2",


### PR DESCRIPTION
## Purpose
> Use folder relative paths for AppAuth-JS dependency since npm install via github is not working for subfolders

## Goals
> Use folder relative paths for AppAuth-JS dependency since npm install via github is not working for subfolders

## Approach
> Since all the dependencies are in the same repo, cloned repo can have relative paths

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A